### PR TITLE
Fix for elixir 1.15

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -17,7 +17,7 @@ defmodule PhoenixHtmlSanitizer.Mixfile do
       ],
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
-      deps: deps
+      deps: deps()
     ]
   end
 


### PR DESCRIPTION
Elixir 1.15 needs `deps()` instead of `deps`. 